### PR TITLE
Update typo in project name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
       auth_url: "{{ cloudstack_auth_url }}"
       username: "{{ cloudstack_login }}"
       password: "{{ cloudstack_password }}"
-      project_name: "{{ cloudstask_project }}"
+      project_name: "{{ cloudstack_project }}"
     auth_type: v2password
     auto_ip: false
     region_name: "{{ vm_region_name }}"


### PR DESCRIPTION
Appears to be a typo in variable name cloudstask_project, changed to cloudstack_project